### PR TITLE
Remove DB hook to fix having sql in binding values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- Fix bindings being wrongly converted to SQL function statements, eg. in `query()->update()` calls.
+
 ## [1.0.0](https://github.com/clickbar/laravel-magellan/tree/1.0.0) - 2023-01-04
 
 - Initial Release 🎉

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ You may find the contents of the published config file here:
 - [x] Geometry and BBox Cast classes
 - [x] Auto Cast when using functions that return geometry or bbox
 - [x] Empty Geometry Support
+- [ ] Custom update Builder method for conversion safety
 - [ ] Automatic PostGIS Function Doc Generator
 - [ ] BBox support within $postgisColumns & trait (currently with cast only)
 - [ ] Custom Geometry Factories & Models

--- a/config/magellan.php
+++ b/config/magellan.php
@@ -57,6 +57,7 @@ return [
      * __toString() method on the geometry objects.
      *
      * It may also be implicitly used, when passing Geometry objects to the DB as bindings in queries.
+     * NOTE: The GeoJson generator will not work for geography columns, since they do not support SRIDs.
      */
     'string_generator' => \Clickbar\Magellan\IO\Generator\WKT\WKTGenerator::class,
 

--- a/config/magellan.php
+++ b/config/magellan.php
@@ -55,6 +55,8 @@ return [
      * The generator that should be used when converting a geometry to a string.
      * This should be a sensitive default for all use-cases and will be used by the
      * __toString() method on the geometry objects.
+     *
+     * It may also be implicitly used, when passing Geometry objects to the DB as bindings in queries.
      */
     'string_generator' => \Clickbar\Magellan\IO\Generator\WKT\WKTGenerator::class,
 


### PR DESCRIPTION
We currently tried to convert bindings, that were geometries, to an SQL representation. This does not work, since bindings are passed as strings to the DB. Thus it cannot execute functions like ST_GeomFromEWKT in such a binding.

So to fix this issue we will for now remove our custom DB hook and let PHP bind our geometries as strings. So it will now implicitly use the string generator.

This method works for all generators and we might consider adding a custom stUpdate command in the future once we need more explicit control.