### PR TITLE
Fix some expressions to use GeometryType enum for $geometryType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- Fix some ST functions not being migrated to the GeometryType enum.
+
 ## [1.0.1](https://github.com/clickbar/laravel-magellan/tree/1.0.1) - 2023-01-05
 
 ### Fixed

--- a/src/Database/PostgisFunctions/MagellanGeometryProcessingFunctions.php
+++ b/src/Database/PostgisFunctions/MagellanGeometryProcessingFunctions.php
@@ -94,11 +94,11 @@ trait MagellanGeometryProcessingFunctions
     public static function centroid($geometry, bool|Expression|\Closure|null $useSpheroid = null, ?GeometryType $geometryType = null): MagellanGeometryExpression
     {
         if ($geometryType === null && $useSpheroid !== null) {
-            $geometryType = 'geography';
+            $geometryType = GeometryType::Geography;
         }
 
         $useSpheroid = $useSpheroid ?? true;
-        $optionalParamters = $geometryType === 'geography' ? [$useSpheroid] : [];
+        $optionalParamters = $geometryType === GeometryType::Geography ? [$useSpheroid] : [];
 
         return MagellanBaseExpression::geometry('ST_Centroid', [GeoParam::wrap($geometry), ...$optionalParamters], $geometryType);
     }

--- a/src/Database/PostgisFunctions/MagellanMeasurementFunctions.php
+++ b/src/Database/PostgisFunctions/MagellanMeasurementFunctions.php
@@ -40,10 +40,10 @@ trait MagellanMeasurementFunctions
     public static function distance($geometryA, $geometryB, bool|Expression|\Closure|null $useSpheroid = null, ?GeometryType $geometryType = null): MagellanNumericExpression
     {
         if ($geometryType === null && $useSpheroid !== null) {
-            $geometryType = 'geography';
+            $geometryType = GeometryType::Geography;
         }
         $useSpheroid = $useSpheroid ?? true;
-        $optionalParamters = $geometryType === 'geography' ? [$useSpheroid] : [];
+        $optionalParamters = $geometryType === GeometryType::Geography ? [$useSpheroid] : [];
 
         return MagellanBaseExpression::numeric('ST_Distance', [GeoParam::wrap($geometryA), GeoParam::wrap($geometryB), ...$optionalParamters], $geometryType);
     }
@@ -148,10 +148,10 @@ trait MagellanMeasurementFunctions
     public static function area($geometry, bool|Expression|\Closure|null $useSpheroid = null, ?GeometryType $geometryType = null): MagellanNumericExpression
     {
         if ($geometryType === null && $useSpheroid !== null) {
-            $geometryType = 'geography';
+            $geometryType = GeometryType::Geography;
         }
         $useSpheroid = $useSpheroid ?? true;
-        $optionalParamters = $geometryType === 'geography' ? [$useSpheroid] : [];
+        $optionalParamters = $geometryType === GeometryType::Geography ? [$useSpheroid] : [];
 
         return MagellanBaseExpression::numeric('ST_Area', [GeoParam::wrap($geometry), ...$optionalParamters], $geometryType);
     }
@@ -170,10 +170,10 @@ trait MagellanMeasurementFunctions
     public static function length($geometry, bool|Expression|\Closure|null $useSpheroid = null, ?GeometryType $geometryType = null): MagellanNumericExpression
     {
         if ($geometryType === null && $useSpheroid !== null) {
-            $geometryType = 'geography';
+            $geometryType = GeometryType::Geography;
         }
         $useSpheroid = $useSpheroid ?? true;
-        $optionalParamters = $geometryType === 'geography' ? [$useSpheroid] : [];
+        $optionalParamters = $geometryType === GeometryType::Geography ? [$useSpheroid] : [];
 
         return MagellanBaseExpression::numeric('ST_Length', [GeoParam::wrap($geometry), ...$optionalParamters], $geometryType);
     }
@@ -305,10 +305,10 @@ trait MagellanMeasurementFunctions
     public static function perimeter($geometry, bool|Expression|\Closure|null $useSpheroid = null, ?GeometryType $geometryType = null): MagellanNumericExpression
     {
         if ($geometryType === null && $useSpheroid !== null) {
-            $geometryType = 'geography';
+            $geometryType = GeometryType::Geography;
         }
         $useSpheroid = $useSpheroid ?? true;
-        $optionalParamters = $geometryType === 'geography' ? [$useSpheroid] : [];
+        $optionalParamters = $geometryType === GeometryType::Geography ? [$useSpheroid] : [];
 
         return MagellanBaseExpression::numeric('ST_Perimeter', [GeoParam::wrap($geometry), ...$optionalParamters], $geometryType);
     }

--- a/src/Database/PostgisFunctions/MagellanTopologicalRelationshipFunctions.php
+++ b/src/Database/PostgisFunctions/MagellanTopologicalRelationshipFunctions.php
@@ -8,6 +8,7 @@ use Clickbar\Magellan\Database\MagellanExpressions\MagellanBaseExpression;
 use Clickbar\Magellan\Database\MagellanExpressions\MagellanBooleanExpression;
 use Clickbar\Magellan\Database\MagellanExpressions\MagellanNumericExpression;
 use Clickbar\Magellan\Database\MagellanExpressions\MagellanStringExpression;
+use Clickbar\Magellan\Enums\GeometryType;
 use Illuminate\Database\Query\Expression;
 
 trait MagellanTopologicalRelationshipFunctions
@@ -64,12 +65,12 @@ trait MagellanTopologicalRelationshipFunctions
      *
      * @param $geometryA
      * @param $geometryB
-     * @param  string|null  $geometryType
+     * @param  \Clickbar\Magellan\Enums\GeometryType|null  $geometryType
      * @return MagellanBooleanExpression
      *
      * @see https://postgis.net/docs/ST_CoveredBy.html
      */
-    public static function coveredBy($geometryA, $geometryB, ?string $geometryType = 'geometry'): MagellanBooleanExpression
+    public static function coveredBy($geometryA, $geometryB, ?GeometryType $geometryType = GeometryType::Geometry): MagellanBooleanExpression
     {
         return MagellanBaseExpression::boolean('ST_CoveredBy', [GeoParam::wrap($geometryA), GeoParam::wrap($geometryB)], $geometryType);
     }
@@ -79,12 +80,12 @@ trait MagellanTopologicalRelationshipFunctions
      *
      * @param $geometryA
      * @param $geometryB
-     * @param  string|null  $geometryType
+     * @param  \Clickbar\Magellan\Enums\GeometryType|null  $geometryType
      * @return MagellanBooleanExpression
      *
      * @see https://postgis.net/docs/ST_Covers.html
      */
-    public static function covers($geometryA, $geometryB, ?string $geometryType = 'geometry'): MagellanBooleanExpression
+    public static function covers($geometryA, $geometryB, ?GeometryType $geometryType = GeometryType::Geometry): MagellanBooleanExpression
     {
         return MagellanBaseExpression::boolean('ST_Covers', [GeoParam::wrap($geometryA), GeoParam::wrap($geometryB)], $geometryType);
     }
@@ -150,12 +151,12 @@ trait MagellanTopologicalRelationshipFunctions
      *
      * @param $geometryA
      * @param $geometryB
-     * @param  string|null  $geometryType
+     * @param  \Clickbar\Magellan\Enums\GeometryType|null  $geometryType
      * @return MagellanBooleanExpression
      *
      * @see https://postgis.net/docs/ST_Intersects.html
      */
-    public static function intersects($geometryA, $geometryB, ?string $geometryType = 'geometry'): MagellanBooleanExpression
+    public static function intersects($geometryA, $geometryB, ?GeometryType $geometryType = GeometryType::Geometry): MagellanBooleanExpression
     {
         return MagellanBaseExpression::boolean('ST_Intersects', [GeoParam::wrap($geometryA), GeoParam::wrap($geometryB)], $geometryType);
     }


### PR DESCRIPTION
Some functions $geometryType parameter was still using the strings, instead of our new GeometryType enum. Thus PHP throws an error when using them.