### PR TITLE
Fix Laravel 10 expression getValue calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- Fix getValue calls on Expressions in Laravel 10
+
 ## [1.1.0](https://github.com/clickbar/laravel-magellan/tree/1.1.0) - 2023-02-07
 
 ### Added

--- a/src/Rules/GeometryGeojsonRule.php
+++ b/src/Rules/GeometryGeojsonRule.php
@@ -6,6 +6,7 @@ use Clickbar\Magellan\IO\Parser\Geojson\GeojsonParser;
 use Illuminate\Contracts\Validation\InvokableRule;
 use Illuminate\Support\Facades\App;
 
+/** @phpstan-ignore-next-line We still need to support Laravel 9 */
 class GeometryGeojsonRule implements InvokableRule
 {
     private array $allowedGeometries;


### PR DESCRIPTION
These functions now require a parameter, the grammar. To avoid builing special version specific code, we are
utilizing the grammar's own wrap() function
which calls getValue on the expression for us.
So this method works for both Laravel 9 & 10.