### PR TITLE
Fixed generation of invalid FeatureCollection in case of zero rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- Fixed generation of invalid FeatureCollection in case of zero database rows (thanks @djfhe)
+
 ## [1.2.0](https://github.com/clickbar/laravel-magellan/tree/1.2.0) - 2023-03-02
 
 ### Improved

--- a/src/Database/Builder/BuilderMacros.php
+++ b/src/Database/Builder/BuilderMacros.php
@@ -137,7 +137,7 @@ class BuilderMacros
             $freshQuery = ($this instanceof EloquentBuilder) ? $this->toBase()->newQuery() : $this->newQuery();
 
             return $freshQuery
-                ->selectRaw("json_build_object('type', 'FeatureCollection', 'features', json_agg(ST_AsGeoJSON(f.*)::json)) AS geojson")
+                ->selectRaw("json_build_object('type', 'FeatureCollection', 'features', COALESCE(json_agg(ST_AsGeoJSON(f.*)::json), ('[]')::json)) AS geojson")
                 ->fromSub($this, 'f')
                 ->first()
                 ->geojson;


### PR DESCRIPTION
Previously the Builder Macro `toGeojsonFeatureCollection` returned `{"type" : "FeatureCollection", "features" : null}` if there are zero database rows.

Now it properly returns `{"type" : "FeatureCollection", "features" : []}`