### PR TITLE
Fixed missing handling of expressions in GeoParam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- Fixed missing handling of expressions in GeoParam
+
 ## [1.2.1](https://github.com/clickbar/laravel-magellan/tree/1.2.1) - 2023-03-28
 
 ### Fixed

--- a/src/Database/Builder/BuilderUtils.php
+++ b/src/Database/Builder/BuilderUtils.php
@@ -99,7 +99,8 @@ class BuilderUtils
                     return 'ARRAY['.self::transformAndJoinParams($value, $generator, $geometryTypeCastAppend, $builder).']';
                 }
 
-                return $value;
+                // process with default handling of the unwrapped GeoParam
+                $param = $value;
             }
 
             // TODO: Check if this can be removed


### PR DESCRIPTION
Since Laravel 10 Expressions are not stringable anymore.
Therefore, using a DB::raw, that created an expression breaks the transformation step.