### PR TITLE
fix: Handling null in TransformsGeojsonGeometry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- Fixed nullable handling in `TransformsGeojsonGeometry` trait (Fixes #37)
+
 ## [1.2.2](https://github.com/clickbar/laravel-magellan/tree/1.2.2) - 2023-03-28
 
 ### Fixed

--- a/src/Http/Requests/TransformsGeojsonGeometry.php
+++ b/src/Http/Requests/TransformsGeojsonGeometry.php
@@ -24,7 +24,7 @@ trait TransformsGeojsonGeometry
         $input = $this->all();
 
         foreach ($attributes as $key) {
-            if (! isset($this[$key])) {
+            if (! isset($this[$key]) || empty($this[$key])) {
                 continue;
             }
 

--- a/tests/Extra/GeometryFormRequest.php
+++ b/tests/Extra/GeometryFormRequest.php
@@ -14,11 +14,12 @@ class GeometryFormRequest extends FormRequest
     {
         return [
             'point' => ['required', new GeometryGeojsonRule()],
+            'nullable_point' => ['nullable', new GeometryGeojsonRule()],
         ];
     }
 
     public function geometries(): array
     {
-        return ['point'];
+        return ['point', 'nullable_point'];
     }
 }

--- a/tests/Http/Requests/TransformsGeojsonGeometryTest.php
+++ b/tests/Http/Requests/TransformsGeojsonGeometryTest.php
@@ -2,53 +2,59 @@
 
 use Clickbar\Magellan\Data\Geometries\Point;
 use Clickbar\Magellan\Tests\Extra\GeometryFormRequest;
+use Illuminate\Contracts\Container\Container;
 use Illuminate\Http\Request;
-use Illuminate\Routing\Route;
-
-test('transforms geojson geometry', function () {
-    $request = GeometryFormRequest::createFrom(createRequest(request: [
-        'point' => '{"type":"Point","coordinates":[8.12345,50.12345]}',
-    ]));
-
-    $request->setContainer($this->app)->validateResolved();
-
-    expect($request->point)->toBeInstanceOf(Point::class);
-
-    $validated = $request->validated();
-    expect($validated['point'])->toBeInstanceOf(Point::class);
-
-    $safe = $request->safe();
-    expect($safe['point'])->toBeInstanceOf(Point::class);
-});
+use Symfony\Component\HttpFoundation\Request as HttpFoundationRequest;
 
 function createRequest(
-    array $query = [],
-    string $method = Request::METHOD_GET,
-    array $request = []
-): Request {
-    $uri = 'http://localhost/en/test';
-    $server = [
-        'REQUEST_URI' => $uri,
-        'CONTENT_TYPE' => 'application/json',
-    ];
+    Container $container = null,
+    array $parameters = [],
+    string $method = Request::METHOD_POST
+): GeometryFormRequest {
+    $request = GeometryFormRequest::createFromBase(HttpFoundationRequest::create('', $method, $parameters));
 
-    $request = new Request(
-        $query,
-        $request,
-        [],
-        [],
-        [],
-        $server,
-        json_encode($request)
-    );
-    $request->setMethod($method);
-
-    $route = (new Route($method, '{locale}/test', [
-        'uses' => 'Controller@index',
-    ]))->bind($request);
-    $request->setRouteResolver(function () use ($route) {
-        return $route;
-    });
+    $request->setRedirector($container->make(\Illuminate\Routing\Redirector::class));
+    $request->setContainer($container);
 
     return $request;
 }
+
+test('transforms geojson geometry', function () {
+    $request = createRequest($this->app, [
+        'point' => '{"type":"Point","coordinates":[8.12345,50.12345]}',
+        'nullable_point' => '{"type":"Point","coordinates":[8.12345,50.12345]}',
+    ]);
+
+    $request->validateResolved();
+
+    expect($request->point)->toBeInstanceOf(Point::class);
+    expect($request->nullable_point)->toBeInstanceOf(Point::class);
+
+    $validated = $request->validated();
+    expect($validated['point'])->toBeInstanceOf(Point::class);
+    expect($validated['nullable_point'])->toBeInstanceOf(Point::class);
+
+    $safe = $request->safe();
+    expect($safe['point'])->toBeInstanceOf(Point::class);
+    expect($safe['nullable_point'])->toBeInstanceOf(Point::class);
+});
+
+test('transforms nullable geojson geometry', function () {
+    $request = createRequest($this->app, [
+        'point' => '{"type":"Point","coordinates":[8.12345,50.12345]}',
+        'nullable_point' => null,
+    ]);
+
+    $request->validateResolved();
+
+    expect($request->point)->toBeInstanceOf(Point::class);
+    expect($request->nullable_point)->toBeNull();
+
+    $validated = $request->validated();
+    expect($validated['point'])->toBeInstanceOf(Point::class);
+    expect($validated['nullable_point'])->toBeNull();
+
+    $safe = $request->safe();
+    expect($safe['point'])->toBeInstanceOf(Point::class);
+    expect($safe['nullable_point'])->toBeNull();
+});


### PR DESCRIPTION
This fixes exceptions thrown when using the TransformsGeojsonGeometry trait with nullable fields.

Additionally, a test case for this problem was added and the createRequest helper function was simplified.

Fixes #37