### PR TITLE
WIP: Adds FeatureCollection support

### DIFF
--- a/src/Data/Features/Feature.php
+++ b/src/Data/Features/Feature.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Clickbar\Magellan\Data\Features;
+
+use Illuminate\Support\Facades\Config;
+use JsonSerializable;
+
+abstract class Feature implements JsonSerializable, \Stringable
+{
+    public function __construct()
+    {
+    }
+
+    public function jsonSerialize(): mixed
+    {
+        $generatorClass = Config::get('magellan.json_generator');
+        $generator = new $generatorClass();
+
+        return $generator->generate($this);
+    }
+
+    public function __toString(): string
+    {
+        return '';
+    }
+}

--- a/src/Data/Features/FeatureCollection.php
+++ b/src/Data/Features/FeatureCollection.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Clickbar\Magellan\Data\Features;
+
+use Clickbar\Magellan\Data\Geometries\Dimension;
+use Clickbar\Magellan\Data\Geometries\Geometry;
+use Countable;
+
+class FeatureCollection extends Feature implements Countable
+{
+    /**
+     * @var Feature[]
+     */
+    protected array $features;
+
+    /**
+     * @param  Feature[]  $features
+     */
+    public static function make(array $features, ?int $srid = null, Dimension $dimension = Dimension::DIMENSION_2D): self
+    {
+        return new self($features, $srid, $dimension);
+
+        // TODO determine if srid and dimension are needed at this level or contained within the Geometry
+    }
+
+    protected function __construct(array $features, ?int $srid = null, Dimension $dimension = Dimension::DIMENSION_2D)
+    {
+        parent::__construct($srid, $dimension);
+
+        // TODO determine if srid and dimension are needed at this level or contained within the Geometry
+
+        GeometryHelper::assertValidGeometryInput(0, Geometry::class, $features, 'geometries');
+        $this->features = $features;
+    }
+
+    /**
+     * @return Feature[]
+     */
+    public function getFeatures(): array
+    {
+        return $this->features;
+    }
+
+    public function count(): int
+    {
+        return count($this->features);
+    }
+}

--- a/src/Data/Features/FeatureFactory.php
+++ b/src/Data/Features/FeatureFactory.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Clickbar\Magellan\Data\Features;
+
+use Clickbar\Magellan\Data\Geometries\Dimension;
+use Clickbar\Magellan\IO\FeatureModelFactory;
+
+class FeatureFactory implements FeatureModelFactory
+{
+    public function createFeatureCollection(Dimension $dimension, ?int $srid, array $features): FeatureCollection
+    {
+        return FeatureCollection::make($features, $srid, $dimension);
+    }
+}

--- a/src/IO/FeatureModelFactory.php
+++ b/src/IO/FeatureModelFactory.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Clickbar\Magellan\IO;
+
+use Clickbar\Magellan\Data\Features\FeatureCollection;
+use Clickbar\Magellan\Data\Geometries\Dimension;
+
+interface FeatureModelFactory
+{
+    /**
+     * TODO docblock
+     */
+    public function createFeatureCollection(
+        Dimension $dimension,
+        ?int $srid,
+        array $features,
+    ): FeatureCollection;
+}

--- a/src/IO/Parser/BaseParser.php
+++ b/src/IO/Parser/BaseParser.php
@@ -3,12 +3,14 @@
 namespace Clickbar\Magellan\IO\Parser;
 
 use Clickbar\Magellan\Data\Geometries\Geometry;
+use Clickbar\Magellan\IO\FeatureModelFactory;
 use Clickbar\Magellan\IO\GeometryModelFactory;
 
 abstract class BaseParser
 {
     public function __construct(
-        protected GeometryModelFactory $factory
+        protected GeometryModelFactory $factory,
+        protected ?FeatureModelFactory $featureFactory = null,
     ) {
     }
 

--- a/src/IO/Parser/Geojson/GeojsonParser.php
+++ b/src/IO/Parser/Geojson/GeojsonParser.php
@@ -2,6 +2,7 @@
 
 namespace Clickbar\Magellan\IO\Parser\Geojson;
 
+use Clickbar\Magellan\Data\Features\Feature;
 use Clickbar\Magellan\Data\Geometries\Dimension;
 use Clickbar\Magellan\Data\Geometries\Geometry;
 use Clickbar\Magellan\IO\Coordinate;
@@ -34,7 +35,7 @@ class GeojsonParser extends BaseParser
             'Point' => $this->parsePoint($input['coordinates']),
             'Polygon' => $this->parsePolygon($input['coordinates']),
             'GeometryCollection' => $this->parseGeomeryCollection($input),
-            'FeatureCollection' => throw new \RuntimeException('Invalid GeoJSON: The type FeatureCollection is not supported'),
+            'FeatureCollection' => $this->parseFeatureCollection($input),
             default => throw new \RuntimeException("Invalid GeoJSON: Invalid GeoJSON type $type"),
         };
     }
@@ -45,6 +46,16 @@ class GeojsonParser extends BaseParser
         $geometries = array_map(fn (array $geometry) => $this->parse($geometry), $geometries);
 
         return $this->factory->createGeometryCollection(Dimension::DIMENSION_2D, 4326, $geometries);
+    }
+
+    protected function parseFeatureCollection(array $featureCollectionData): Feature
+    {
+        $features = $featureCollectionData['features'];
+
+        // TODO - Parse `properties` and `id` from the feature collection
+        $geometries = array_map(fn (array $feature) => $this->parse($feature['geometry']), $features);
+
+        return $this->featureFactory->createFeatureCollection(Dimension::DIMENSION_2D, 4326, $geometries);
     }
 
     protected function parsePoint(array $coordinates): Geometry

--- a/src/MagellanServiceProvider.php
+++ b/src/MagellanServiceProvider.php
@@ -3,8 +3,10 @@
 namespace Clickbar\Magellan;
 
 use Clickbar\Magellan\Commands\UpdatePostgisColumns;
+use Clickbar\Magellan\Data\Features\FeatureFactory;
 use Clickbar\Magellan\Data\Geometries\GeometryFactory;
 use Clickbar\Magellan\Database\Builder\BuilderMacros;
+use Clickbar\Magellan\IO\FeatureModelFactory;
 use Clickbar\Magellan\IO\GeometryModelFactory;
 use Clickbar\Magellan\IO\Parser\Geojson\GeojsonParser;
 use Clickbar\Magellan\IO\Parser\WKB\WKBParser;
@@ -46,16 +48,20 @@ class MagellanServiceProvider extends PackageServiceProvider
             return new GeometryFactory();
         });
 
+        $this->app->singleton(FeatureModelFactory::class, function ($app) {
+            return new FeatureFactory();
+        });
+
         $this->app->singleton(GeojsonParser::class, function ($app) {
-            return new GeojsonParser($app->make(GeometryModelFactory::class));
+            return new GeojsonParser($app->make(GeometryModelFactory::class), $app->make(FeatureModelFactory::class));
         });
 
         $this->app->singleton(WKTParser::class, function ($app) {
-            return new WKTParser($app->make(GeometryModelFactory::class));
+            return new WKTParser($app->make(GeometryModelFactory::class), null);
         });
 
         $this->app->singleton(WKBParser::class, function ($app) {
-            return new WKBParser($app->make(GeometryModelFactory::class));
+            return new WKBParser($app->make(GeometryModelFactory::class), null);
         });
 
         // Register custom Doctrine types for PostGIS only if DBAL is available


### PR DESCRIPTION
So was digging for a cool package to help with some GeoJSON parsing in our Laravel app, found this and it error`d out on initial parsing with:

```
Invalid GeoJSON: The type FeatureCollection is not supported
```

Seeing how it was open source, I dove in to fix/add and I noticed maybe why it was left unresolved. Thankfully after the last few days of spending time with GeoJSON, I got the spec down pretty well.

---

Since Features are just a mixture of `geometry` and `properties` I figured this would be easy. Just supporting the existing parsing of `geometry` and a new parsing of custom key/value pairs.

Until I read the [RFC](https://datatracker.ietf.org/doc/html/rfc7946#section-3.2). It says

> A Feature object has a member with the name "properties".  The value of the properties member is an object (any JSON object or a JSON null value).

So my idea of a simple key/value falls apart if you are allowed to have a JSON object (of any shape) or null.

However, as I started writing this. It was taking a good deal of changes to support introducing a new class that simply sub-classed Geometries and I felt a bit uneasy with how much I was changing.

Before I go further, may someone peek if I am going about this a wrong way or have any tips?

* I don't really like that I had to make a new factory class, but it felt wrong packing features onto Geometry classes as they live higher than that.

