### PR TITLE
ci: Rename and run check styling on prs too

### DIFF
--- a/.github/workflows/check-styling.yml
+++ b/.github/workflows/check-styling.yml
@@ -1,12 +1,15 @@
 name: Check styling
 
-on: [push]
+on:
+  push:
+  pull_request:
+    branches: [main]
 
 permissions:
   contents: read
 
 jobs:
-  fix-styling:
+  check-styling:
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
We require the check to be successful, but we do not run it on pull requests.