### PR TITLE
fix(docblocks): Mitigate issue in ide-helper docblock parsing 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added `as` parameter for `stFrom` function
 
+### Fixed
+
+- Fixed builder macro docblocks to use FQDN for an issue within laravel-ide-helper
+
 ## [1.4.0](https://github.com/clickbar/laravel-magellan/tree/1.4.0) - 2023-07-02
 
 ### Improved

--- a/src/Database/Builder/BuilderMacros.php
+++ b/src/Database/Builder/BuilderMacros.php
@@ -1,5 +1,15 @@
 <?php
 
+/**
+ * Disabled for now, to mitigate issues with the Laravel IDE Helper Generator.
+ * PLEASE keep parameter annotations in here with their fully qualified class names, so that the IDE Helper Generator
+ * can pick them up properly.
+ * See https://github.com/barryvdh/laravel-ide-helper/pull/953
+ *
+ * @noinspection PhpFullyQualifiedNameUsageInspection
+ * @noinspection PhpUnnecessaryFullyQualifiedNameInspection
+ */
+
 namespace Clickbar\Magellan\Database\Builder;
 
 use Clickbar\Magellan\Cast\BBoxCast;
@@ -54,7 +64,7 @@ class BuilderMacros
     {
         /**
          * @param  \Clickbar\Magellan\Database\MagellanExpressions\MagellanNumericExpression|\Clickbar\Magellan\Database\MagellanExpressions\MagellanBooleanExpression  $magellanExpression
-         * @param  string|null  $direction
+         * @param  string  $direction
          * @return static
          */
         return function (MagellanNumericExpression|MagellanBooleanExpression $magellanExpression, string $direction = 'ASC') {
@@ -65,7 +75,7 @@ class BuilderMacros
     public function stWhere()
     {
         /**
-         * @param  \Clickbar\Magellan\Database\MagellanExpressions\MagellanStringExpression|\Clickbar\Magellan\Database\MagellanExpressions\MagellanBooleanExpression|\Clickbar\Magellan\Database\MagellanExpressions\MagellanBBoxExpression|\Clickbar\Magellan\Database\MagellanExpressions\MagellanNumericExpression|\Clickbar\Magellan\Database\MagellanExpressions\MagellanGeometryExpression|\Clickbar\Magellan\Database\MagellanExpressions\MagellanGeometryOrBboxExpression|Geometry|Box2D|Box3D|string  $column
+         * @param  \Clickbar\Magellan\Database\MagellanExpressions\MagellanStringExpression|\Clickbar\Magellan\Database\MagellanExpressions\MagellanBooleanExpression|\Clickbar\Magellan\Database\MagellanExpressions\MagellanBBoxExpression|\Clickbar\Magellan\Database\MagellanExpressions\MagellanNumericExpression|\Clickbar\Magellan\Database\MagellanExpressions\MagellanGeometryExpression|\Clickbar\Magellan\Database\MagellanExpressions\MagellanGeometryOrBboxExpression|\Clickbar\Magellan\Data\Geometries\Geometry|\Clickbar\Magellan\Data\Boxes\Box2D|\Clickbar\Magellan\Data\Boxes\Box3D|string  $column
          * @param  mixed  $operator
          * @param  mixed  $value
          * @param  string|null  $boolean
@@ -83,7 +93,7 @@ class BuilderMacros
     public function stOrWhere()
     {
         /**
-         * @param  \Clickbar\Magellan\Database\MagellanExpressions\MagellanStringExpression|\Clickbar\Magellan\Database\MagellanExpressions\MagellanBooleanExpression|\Clickbar\Magellan\Database\MagellanExpressions\MagellanBBoxExpression|\Clickbar\Magellan\Database\MagellanExpressions\MagellanNumericExpression|\Clickbar\Magellan\Database\MagellanExpressions\MagellanGeometryExpression|\Clickbar\Magellan\Database\MagellanExpressions\MagellanGeometryOrBboxExpression|Geometry|Box2D|Box3D|string  $column
+         * @param  \Clickbar\Magellan\Database\MagellanExpressions\MagellanStringExpression|\Clickbar\Magellan\Database\MagellanExpressions\MagellanBooleanExpression|\Clickbar\Magellan\Database\MagellanExpressions\MagellanBBoxExpression|\Clickbar\Magellan\Database\MagellanExpressions\MagellanNumericExpression|\Clickbar\Magellan\Database\MagellanExpressions\MagellanGeometryExpression|\Clickbar\Magellan\Database\MagellanExpressions\MagellanGeometryOrBboxExpression|\Clickbar\Magellan\Data\Geometries\Geometry|\Clickbar\Magellan\Data\Boxes\Box2D|\Clickbar\Magellan\Data\Boxes\Box3D|string  $column
          * @param  mixed  $operator
          * @param  mixed  $value
          * @return static
@@ -100,7 +110,7 @@ class BuilderMacros
     public function stGroupBy()
     {
         /**
-         * @param  array|string|MagellanBaseExpression  ...$groups
+         * @param  array|string|\Clickbar\Magellan\Database\MagellanExpressions\MagellanBaseExpression  ...$groups
          * @return static
          */
         return function (...$groups) {


### PR DESCRIPTION
The generation code has some issues with imported class names in docblocks. It does not resolve those properly and thus leads to incorrect annotations. This was mitigated by transforming all current macro annotations to use the fully qualified class names

See https://github.com/barryvdh/laravel-ide-helper/pull/953

Before this PR:
```php
/**
 *
 *
 * @param array|string|\MagellanBaseExpression $groups
 * @return static
 * @see \Clickbar\Magellan\Database\Builder\BuilderMacros::stGroupBy()
 * @static
 */
public static function stGroupBy(...$groups)
{
    return \Illuminate\Database\Query\Builder::stGroupBy(...$groups);
}
```

After:
```php
/**
 *
 *
 * @param array|string|\Clickbar\Magellan\Database\MagellanExpressions\MagellanBaseExpression $groups
 * @return static
 * @see \Clickbar\Magellan\Database\Builder\BuilderMacros::stGroupBy()
 * @static
 */
public static function stGroupBy(...$groups)
{
    return \Illuminate\Database\Query\Builder::stGroupBy(...$groups);
}
```