### PR TITLE
Overrides getAttributesForInsert & getDirtyForUpdate instead of performInsert & performUpdate to 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Improved
+- Only override attribute preparation functions on models instead of `performInsert` or `performUpdate` entirely (thanks @RomainMazB #89)
+
+### Fixed
+- Fixed geometries not being passed to model events (fixes #87) (thanks @RomainMazB #89)
+
 ## [1.6.0](https://github.com/clickbar/laravel-magellan/tree/1.6.0) - 2024-03-17
 
 ### Added

--- a/src/Database/Eloquent/HasPostgisColumns.php
+++ b/src/Database/Eloquent/HasPostgisColumns.php
@@ -9,7 +9,6 @@ use Clickbar\Magellan\Exception\SridMissmatchException;
 use Clickbar\Magellan\IO\Generator\BaseGenerator;
 use Clickbar\Magellan\IO\Generator\WKT\WKTGenerator;
 use Clickbar\Magellan\IO\Parser\WKB\WKBParser;
-use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\App;


### PR DESCRIPTION
This fix #87 by decreasing the code override from the Eloquent Model class.
- Instead of overriding the whole `performInsert` method, we now override the `getAttributesForInsert` method which only cares about getting the attributes to be inserted into the database.
- Instead of overriding the whole `performUpdate` method, we now override the `getDirtyForUpdate` method which only cares about getting the modified attributes to be updated into the database.