### PR TITLE
Update Point.php to update dimension when using setAltitude

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Improved
 - Updated `spatie/invade` to v2, works without reflection now 🥳
 
+### Fixed
+- Fixed not updating `Point` dimension when using `setAltitude` 
+
 ## [1.5.0](https://github.com/clickbar/laravel-magellan/tree/1.5.0) - 2024-01-19
 
 ### Added

--- a/src/Data/Geometries/Point.php
+++ b/src/Data/Geometries/Point.php
@@ -120,40 +120,37 @@ class Point extends Geometry
     public function getLatitude(): float
     {
         $this->assertPointIsGeodetic();
-
         return $this->y;
     }
 
     public function setLatitude(float $latitude): void
     {
         $this->assertPointIsGeodetic();
-        $this->y = $latitude;
+        $this->setY($latitude);
     }
 
     public function getLongitude(): float
     {
         $this->assertPointIsGeodetic();
-
         return $this->x;
     }
 
     public function setLongitude(float $longitude): void
     {
         $this->assertPointIsGeodetic();
-        $this->x = $longitude;
+        $this->setX($longitude);
     }
 
     public function getAltitude(): ?float
     {
         $this->assertPointIsGeodetic();
-
         return $this->z;
     }
 
     public function setAltitude(float $altitude): void
     {
         $this->assertPointIsGeodetic();
-        $this->z = $altitude;
+        $this->setZ($altitude);
     }
 
     private function assertPointIsGeodetic()

--- a/src/Data/Geometries/Point.php
+++ b/src/Data/Geometries/Point.php
@@ -120,6 +120,7 @@ class Point extends Geometry
     public function getLatitude(): float
     {
         $this->assertPointIsGeodetic();
+
         return $this->y;
     }
 
@@ -132,6 +133,7 @@ class Point extends Geometry
     public function getLongitude(): float
     {
         $this->assertPointIsGeodetic();
+
         return $this->x;
     }
 
@@ -144,6 +146,7 @@ class Point extends Geometry
     public function getAltitude(): ?float
     {
         $this->assertPointIsGeodetic();
+
         return $this->z;
     }
 


### PR DESCRIPTION
I ran into this issue by converting a LineString object via the WKTGenerator to a wkt string. Even though every point has a z value  the value is not included in the resulting converted wkt string.

Before the converting is done I am setting new altitude / z values for each point via the setAltitude function. I saw that this function doesn't call the updateDimension function like setZ function would do. When I use the setZ function everything works fine. So I changed the setAltitude function to call the internal setZ function and made this logical change to setLatitude and setLongitude as well.

I hope I have done everything right because this is my first pull request.
Please let me know if I made any mistakes.