### PR TITLE
fix(builder): add missing schema prefix to ST SQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed `Expression` types in SRID-related functions
+- Fixed missing schema prefix for generated SQL of first-level `ST` functions
 
 ## [1.6.1](https://github.com/clickbar/laravel-magellan/tree/1.6.1) - 2024-08-08
 

--- a/src/Database/Builder/BuilderUtils.php
+++ b/src/Database/Builder/BuilderUtils.php
@@ -31,7 +31,7 @@ class BuilderUtils
         $generator = new $generatorClass();
         $paramString = self::transformAndJoinParams($params, $generator, $geometryTypeCastAppend, $builder);
 
-        $expressionString = "$function($paramString)";
+        $expressionString = Config::get('magellan.schema').'.'."$function($paramString)";
 
         if ($as) {
             $expressionString .= " AS $as";


### PR DESCRIPTION
The schema was never added to the ST functions on the first level. This is usually no problem, because people use the public schema anyway. Though for correctness and to properly support changing the schema we fixed this.