### PR TITLE
fix(builder): numeric SRID SQL queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed `Expression` types in SRID-related functions
 - Fixed missing schema prefix for generated SQL of first-level `ST` functions
+- Fixed numeric SRID queries in `ST::transform` and `ST::setSRID` (thanks @BezBIS #91)
 
 ## [1.6.1](https://github.com/clickbar/laravel-magellan/tree/1.6.1) - 2024-08-08
 

--- a/src/Database/PostgisFunctions/MagellanSpatialReferenceSystemFunctions.php
+++ b/src/Database/PostgisFunctions/MagellanSpatialReferenceSystemFunctions.php
@@ -13,11 +13,17 @@ trait MagellanSpatialReferenceSystemFunctions
     /**
      * Sets the SRID on a geometry to a particular integer value. Useful in constructing bounding boxes for queries.
      *
+     * NOTE: If you use an Expression or Closure for the SRID, you might need to add an `::int` cast.
+     * See https://stackoverflow.com/questions/66625661/cannot-bind-value-as-int-with-pdo-pgsql-driver
      *
      * @see https://postgis.net/docs/ST_SetSRID.html
      */
     public static function setSrid($geometry, int|Expression|\Closure $srid): MagellanGeometryExpression
     {
+        if (is_int($srid)) {
+            $srid = new Expression($srid.'::int');
+        }
+
         return MagellanBaseExpression::geometry('ST_SetSRID', [GeoParam::wrap($geometry), $srid]);
     }
 
@@ -42,12 +48,17 @@ trait MagellanSpatialReferenceSystemFunctions
      * - geometry ST_Transform(geometry geom, text from_proj, text to_proj);
      * - geometry ST_Transform(geometry geom, text from_proj, integer to_srid);
      *
+     * NOTE: If you use an Expression or Closure for the SRID, you might need to add an `::int` cast.
+     * See https://stackoverflow.com/questions/66625661/cannot-bind-value-as-int-with-pdo-pgsql-driver
      *
      * @see https://postgis.net/docs/ST_Transform.html
      */
     public static function transform($geometry, int|Expression|\Closure|null $srid = null, string|Expression|\Closure|null $fromProjection = null, string|Expression|\Closure|null $toProjection = null, int|Expression|\Closure|null $toSrid = null): MagellanGeometryExpression
     {
-        // TODO: Consider throwing exception when the overloading does not suite the available possibilitirs:
+        if (is_int($srid)) {
+            $srid = new Expression($srid.'::int');
+        }
+
         return MagellanBaseExpression::geometry('ST_Transform', [GeoParam::wrap($geometry), $srid, $fromProjection, $toProjection, $toSrid]);
     }
 }


### PR DESCRIPTION
When using numeric values for the SRID in functions like `ST_Transform`, the query will throw an error that it cannot parse the SRID projection.

This seems to be caused by the PDO driver, which internally always converts parameters to strings.
See https://stackoverflow.com/questions/66625661/cannot-bind-value-as-int-with-pdo-pgsql-driver

We now append a `::int` cast to numeric SRID parameters, so they work as expected again.

For Closures and Expressions, the developer needs to take care of this. We added a note to make them aware of this behavior.