### PR TITLE
feat(ST): add asGeoJson function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
+
 - PostGIS ST_LineSubstring support
 - PostGIS ST_LineFromEncodedPolyline support
 - PostGIS ST_LineLocatePoint support
+- Added `ST::asGeoJson` function to convert geometries to GeoJSON via the database
 
 ### Fixed
 

--- a/src/Database/PostgisFunctions/MagellanOtherFormatFunctions.php
+++ b/src/Database/PostgisFunctions/MagellanOtherFormatFunctions.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Clickbar\Magellan\Database\PostgisFunctions;
+
+use Clickbar\Magellan\Database\MagellanExpressions\GeoParam;
+use Clickbar\Magellan\Database\MagellanExpressions\MagellanBaseExpression;
+use Clickbar\Magellan\Database\MagellanExpressions\MagellanStringExpression;
+use Clickbar\Magellan\Enums\GeojsonOutputOption;
+use Clickbar\Magellan\Enums\GeometryType;
+use Illuminate\Database\Query\Expression;
+
+trait MagellanOtherFormatFunctions
+{
+    /**
+     * Returns a geometry as a GeoJSON "geometry", or a row as a GeoJSON "feature". (See the GeoJSON specifications RFC 7946). 2D and 3D Geometries are both supported. GeoJSON only support SFS 1.1 geometry types (no curve support for example).
+     *
+     * @param  int|Expression|\Closure  $maximalDecimalDigits  may be used to reduce the maximum number of decimal places used in output (defaults to 9). If you are using EPSG:4326 and are outputting the geometry only for display, maxdecimaldigits=6 can be a good choice for many maps.
+     * @param  GeojsonOutputOption[]  $options
+     *
+     * @see https://postgis.net/docs/ST_AsGeoJSON.html
+     */
+    public static function asGeoJson($geometry, int|Expression|\Closure $maximalDecimalDigits = 9, array $options = [], ?GeometryType $geometryType = null): MagellanStringExpression
+    {
+        $optionalParameters = [$maximalDecimalDigits];
+        if (! empty($options)) {
+            $optionalParameters[] = collect($options)->reduce(fn (int $flags, GeojsonOutputOption $option) => $flags | $option->value, 0);
+        }
+
+        return MagellanBaseExpression::string('ST_AsGeoJSON', [GeoParam::wrap($geometry), ...$optionalParameters], $geometryType);
+    }
+}

--- a/src/Database/PostgisFunctions/ST.php
+++ b/src/Database/PostgisFunctions/ST.php
@@ -11,6 +11,7 @@ class ST
     use MagellanGeometryProcessingFunctions;
     use MagellanGeometryValidationFunctions;
     use MagellanMeasurementFunctions;
+    use MagellanOtherFormatFunctions;
     use MagellanOverlayFunctions;
     use MagellanSpatialReferenceSystemFunctions;
     use MagellanTopologicalRelationshipFunctions;

--- a/src/Enums/GeojsonOutputOption.php
+++ b/src/Enums/GeojsonOutputOption.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Clickbar\Magellan\Enums;
+
+enum GeojsonOutputOption: int
+{
+    case NoOption = 0;
+    case Bbox = 1;
+    case ShortCrs = 2;
+    case LongCrs = 4;
+    case ShortCrsIfNot4326 = 8;
+}


### PR DESCRIPTION
We added the `ST_AsGeoJSON` function to the `ST` builder class.
This can come in handy when building queries for the frontend.