### PR TITLE
[2.x] Specific Casts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added `GeometryCast` to cast geometries instead of the `GeometryWKBCast`
+- Added `Castable` to all geometries to use them as casters, instead of the `GeometryWKBCast`
 - Added `Aliased` Expression class as wrapper for `AS` in query selects
 - Added `withMagellanCasts()` as EloquentBuilder macro
 

--- a/README.md
+++ b/README.md
@@ -107,12 +107,12 @@ $table->magellanPoint('location', 4326);
 
 ## Preparing the Model
 
-In order to properly integrate everything with the model you only need to add the appropriate cast:
+In order to properly integrate everything with the model you only need to add the appropriate cast (each Geometry can be used):
 
 ```php
 protected $casts = [
     /** ... */
-    'location' => GeometryCast::class,
+    'location' => Point::class,
 ];
 ```
 
@@ -274,7 +274,7 @@ class Port extends Model
     protected $guarded = [];
 
     protected $casts = [
-        'location' => GeometryCast::class,
+        'location' => Point::class,
     ];
 }
 ```
@@ -473,7 +473,7 @@ $hullWithArea = Port::query()
         new Aliased(ST::area(ST::convexHull(ST::collect('location'))), 'area')
     ])
     ->groupBy('country')
-    ->withCasts(['hull' => GeometryCast::class]) /* <======= */
+    ->withCasts(['hull' => Polygon::class]) /* <======= */
     ->first();
 
 ```

--- a/composer.lock
+++ b/composer.lock
@@ -3098,16 +3098,16 @@
         },
         {
             "name": "spatie/laravel-package-tools",
-            "version": "1.17.0",
+            "version": "1.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/laravel-package-tools.git",
-                "reference": "9ab30fd24f677e5aa370ea4cf6b41c517d16cf85"
+                "reference": "8332205b90d17164913244f4a8e13ab7e6761d29"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/laravel-package-tools/zipball/9ab30fd24f677e5aa370ea4cf6b41c517d16cf85",
-                "reference": "9ab30fd24f677e5aa370ea4cf6b41c517d16cf85",
+                "url": "https://api.github.com/repos/spatie/laravel-package-tools/zipball/8332205b90d17164913244f4a8e13ab7e6761d29",
+                "reference": "8332205b90d17164913244f4a8e13ab7e6761d29",
                 "shasum": ""
             },
             "require": {
@@ -3146,7 +3146,7 @@
             ],
             "support": {
                 "issues": "https://github.com/spatie/laravel-package-tools/issues",
-                "source": "https://github.com/spatie/laravel-package-tools/tree/1.17.0"
+                "source": "https://github.com/spatie/laravel-package-tools/tree/1.18.0"
             },
             "funding": [
                 {
@@ -3154,7 +3154,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-12-09T16:29:14+00:00"
+            "time": "2024-12-30T13:13:39+00:00"
         },
         {
             "name": "symfony/clock",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,7 +9,7 @@
     <env name="DB_CONNECTION" value="pgsql"/>
     <env name="DB_DATABASE" value="testing"/>
     <env name="DB_USERNAME" value="postgres"/>
-    <env name="DB_PASSWORD" value="postgres"/>
+    <env name="DB_PASSWORD" value="password"/>
   </php>
   <coverage/>
   <source>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,7 +9,7 @@
     <env name="DB_CONNECTION" value="pgsql"/>
     <env name="DB_DATABASE" value="testing"/>
     <env name="DB_USERNAME" value="postgres"/>
-    <env name="DB_PASSWORD" value="password"/>
+    <env name="DB_PASSWORD" value="postgres"/>
   </php>
   <coverage/>
   <source>

--- a/src/Cast/GeometryCast.php
+++ b/src/Cast/GeometryCast.php
@@ -11,7 +11,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\App;
 
 /**
- * @internal
+ * @internal Use the specific Geometry (sub)class as caster in the model e.g. Point::class or Geometry::class
  *
  * @template T of Geometry
  *

--- a/src/Cast/GeometryCast.php
+++ b/src/Cast/GeometryCast.php
@@ -15,7 +15,7 @@ use Illuminate\Support\Facades\App;
  *
  * @template T of Geometry
  *
- * @implements  CastsAttributes<T,T>
+ * @implements CastsAttributes<T,T>
  */
 class GeometryCast implements CastsAttributes
 {
@@ -38,7 +38,6 @@ class GeometryCast implements CastsAttributes
      * Cast the given value.
      *
      * @param  Model  $model
-     * @return T|null
      */
     public function get($model, string $key, mixed $value, array $attributes)
     {

--- a/src/Cast/GeometryCast.php
+++ b/src/Cast/GeometryCast.php
@@ -11,7 +11,11 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\App;
 
 /**
- * @implements CastsAttributes<Geometry,Geometry>
+ * @internal
+ *
+ * @template T of Geometry
+ *
+ * @implements  CastsAttributes<T,T>
  */
 class GeometryCast implements CastsAttributes
 {
@@ -19,22 +23,33 @@ class GeometryCast implements CastsAttributes
 
     protected BaseGenerator $sqlGenerator;
 
-    public function __construct()
-    {
+    /** @param class-string<T> $geometryClass */
+    public function __construct(
+        protected string $geometryClass,
+    ) {
         $this->wkbParser = App::make(WKBParser::class);
 
         $generatorClass = config('magellan.sql_generator', WKTGenerator::class);
         $this->sqlGenerator = new $generatorClass;
+
     }
 
     /**
      * Cast the given value.
      *
      * @param  Model  $model
+     * @return T|null
      */
     public function get($model, string $key, mixed $value, array $attributes)
     {
-        return isset($value) ? $this->wkbParser->parse($value) : null;
+        if (! isset($value)) {
+            return null;
+        }
+
+        $geometry = $this->wkbParser->parse($value);
+        $this->assertGeometryType($geometry);
+
+        return $geometry;
     }
 
     /**
@@ -45,9 +60,19 @@ class GeometryCast implements CastsAttributes
     public function set($model, string $key, mixed $value, array $attributes)
     {
         if ($value instanceof Geometry) {
+            $this->assertGeometryType($value);
+
             return $this->sqlGenerator->generate($value);
         }
 
         return $value;
+    }
+
+    protected function assertGeometryType(Geometry $geometry): void
+    {
+        if (! $geometry instanceof $this->geometryClass) {
+            $actualClass = get_class($geometry);
+            throw new \InvalidArgumentException("Geometry type must be an instance of $this->geometryClass, $actualClass given");
+        }
     }
 }

--- a/src/Data/Geometries/Geometry.php
+++ b/src/Data/Geometries/Geometry.php
@@ -2,10 +2,12 @@
 
 namespace Clickbar\Magellan\Data\Geometries;
 
+use Clickbar\Magellan\Cast\GeometryCast;
+use Illuminate\Contracts\Database\Eloquent\Castable;
 use Illuminate\Support\Facades\Config;
 use JsonSerializable;
 
-abstract class Geometry implements \Stringable, GeometryInterface, JsonSerializable
+abstract class Geometry implements \Stringable, Castable, GeometryInterface, JsonSerializable
 {
     public function __construct(
         protected ?int $srid = null,
@@ -50,5 +52,12 @@ abstract class Geometry implements \Stringable, GeometryInterface, JsonSerializa
         }
 
         return $generated;
+    }
+
+    public static function castUsing(array $arguments): GeometryCast
+    {
+        $class = static::class;
+
+        return new GeometryCast($class);
     }
 }

--- a/src/Data/Geometries/GeometryCollection.php
+++ b/src/Data/Geometries/GeometryCollection.php
@@ -2,6 +2,7 @@
 
 namespace Clickbar\Magellan\Data\Geometries;
 
+use Clickbar\Magellan\Cast\GeometryCast;
 use Countable;
 
 class GeometryCollection extends Geometry implements Countable
@@ -61,5 +62,11 @@ class GeometryCollection extends Geometry implements Countable
     public function count(): int
     {
         return count($this->geometries);
+    }
+
+    /** @return GeometryCast<GeometryCollection> */
+    public static function castUsing(array $arguments): GeometryCast
+    {
+        return new GeometryCast(GeometryCollection::class);
     }
 }

--- a/src/Data/Geometries/LineString.php
+++ b/src/Data/Geometries/LineString.php
@@ -2,6 +2,8 @@
 
 namespace Clickbar\Magellan\Data\Geometries;
 
+use Clickbar\Magellan\Cast\GeometryCast;
+
 class LineString extends PointCollection
 {
     /**
@@ -10,5 +12,11 @@ class LineString extends PointCollection
     public static function make(array $points, ?int $srid = null, Dimension $dimension = Dimension::DIMENSION_2D): self
     {
         return new self($points, $srid, $dimension);
+    }
+
+    /** @return GeometryCast<LineString> */
+    public static function castUsing(array $arguments): GeometryCast
+    {
+        return new GeometryCast(LineString::class);
     }
 }

--- a/src/Data/Geometries/MultiLineString.php
+++ b/src/Data/Geometries/MultiLineString.php
@@ -2,6 +2,7 @@
 
 namespace Clickbar\Magellan\Data\Geometries;
 
+use Clickbar\Magellan\Cast\GeometryCast;
 use Countable;
 
 class MultiLineString extends Geometry implements Countable
@@ -61,5 +62,11 @@ class MultiLineString extends Geometry implements Countable
     public function count(): int
     {
         return count($this->lineStrings);
+    }
+
+    /** @return GeometryCast<MultiLineString> */
+    public static function castUsing(array $arguments): GeometryCast
+    {
+        return new GeometryCast(MultiLineString::class);
     }
 }

--- a/src/Data/Geometries/MultiPoint.php
+++ b/src/Data/Geometries/MultiPoint.php
@@ -2,6 +2,8 @@
 
 namespace Clickbar\Magellan\Data\Geometries;
 
+use Clickbar\Magellan\Cast\GeometryCast;
+
 class MultiPoint extends PointCollection
 {
     /**
@@ -10,5 +12,11 @@ class MultiPoint extends PointCollection
     public static function make(array $points, ?int $srid = null, Dimension $dimension = Dimension::DIMENSION_2D): self
     {
         return new self($points, $srid, $dimension);
+    }
+
+    /** @return GeometryCast<MultiPoint> */
+    public static function castUsing(array $arguments): GeometryCast
+    {
+        return new GeometryCast(MultiPoint::class);
     }
 }

--- a/src/Data/Geometries/MultiPolygon.php
+++ b/src/Data/Geometries/MultiPolygon.php
@@ -2,6 +2,8 @@
 
 namespace Clickbar\Magellan\Data\Geometries;
 
+use Clickbar\Magellan\Cast\GeometryCast;
+
 class MultiPolygon extends Geometry implements \Countable
 {
     /**
@@ -62,5 +64,11 @@ class MultiPolygon extends Geometry implements \Countable
     public function count(): int
     {
         return count($this->polygons);
+    }
+
+    /** @return GeometryCast<MultiPolygon> */
+    public static function castUsing(array $arguments): GeometryCast
+    {
+        return new GeometryCast(MultiPolygon::class);
     }
 }

--- a/src/Data/Geometries/Point.php
+++ b/src/Data/Geometries/Point.php
@@ -2,6 +2,7 @@
 
 namespace Clickbar\Magellan\Data\Geometries;
 
+use Clickbar\Magellan\Cast\GeometryCast;
 use Clickbar\Magellan\Exception\MissingGeodeticSRIDException;
 
 class Point extends Geometry
@@ -161,5 +162,11 @@ class Point extends Geometry
         if (! $this->isGeodetic()) {
             throw new MissingGeodeticSRIDException($this->getSrid());
         }
+    }
+
+    /** @return GeometryCast<Point> */
+    public static function castUsing(array $arguments): GeometryCast
+    {
+        return new GeometryCast(Point::class);
     }
 }

--- a/src/Data/Geometries/Polygon.php
+++ b/src/Data/Geometries/Polygon.php
@@ -2,6 +2,8 @@
 
 namespace Clickbar\Magellan\Data\Geometries;
 
+use Clickbar\Magellan\Cast\GeometryCast;
+
 class Polygon extends MultiLineString
 {
     /**
@@ -10,5 +12,11 @@ class Polygon extends MultiLineString
     public static function make(array $lineStrings, ?int $srid = null, Dimension $dimension = Dimension::DIMENSION_2D): self
     {
         return new self($lineStrings, $srid, $dimension);
+    }
+
+    /** @return GeometryCast<Polygon> */
+    public static function castUsing(array $arguments): GeometryCast
+    {
+        return new GeometryCast(Polygon::class);
     }
 }

--- a/src/Database/Builder/EloquentBuilderMacros.php
+++ b/src/Database/Builder/EloquentBuilderMacros.php
@@ -13,7 +13,7 @@
 namespace Clickbar\Magellan\Database\Builder;
 
 use Clickbar\Magellan\Cast\BBoxCast;
-use Clickbar\Magellan\Cast\GeometryCast;
+use Clickbar\Magellan\Data\Geometries\Geometry;
 use Clickbar\Magellan\Database\Expressions\Aliased;
 use Clickbar\Magellan\Database\MagellanExpressions\MagellanBaseExpression;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
@@ -51,7 +51,7 @@ class EloquentBuilderMacros
                 }
 
                 if ($magellanExpression?->returnsGeometry()) {
-                    $this->withCasts([$alias => GeometryCast::class]);
+                    $this->withCasts([$alias => Geometry::class]);
                 }
             }
 

--- a/tests/Models/Geometry.php
+++ b/tests/Models/Geometry.php
@@ -2,7 +2,9 @@
 
 namespace Clickbar\Magellan\Tests\Models;
 
-use Clickbar\Magellan\Cast\GeometryCast;
+use Clickbar\Magellan\Data\Geometries\LineString;
+use Clickbar\Magellan\Data\Geometries\Point;
+use Clickbar\Magellan\Data\Geometries\Polygon;
 use Illuminate\Database\Eloquent\Model;
 
 class Geometry extends Model
@@ -15,8 +17,8 @@ class Geometry extends Model
     ];
 
     protected $casts = [
-        'point' => GeometryCast::class,
-        'line' => GeometryCast::class,
-        'area' => GeometryCast::class,
+        'point' => Point::class,
+        'line' => LineString::class,
+        'area' => Polygon::class,
     ];
 }

--- a/tests/Models/GeometryTypesTest.php
+++ b/tests/Models/GeometryTypesTest.php
@@ -76,3 +76,19 @@ test('it can handle empty geometries', function () {
     expect($geometry->line->isEmpty())->toBeTrue();
     expect($geometry->area->isEmpty())->toBeTrue();
 });
+
+test('it throws an exception when the wrong caster is used', function () {
+
+    $geometry = Geometry::create([
+        'name' => 'Empty Geometries',
+        'point' => Point::make(NAN, NAN, null, null, 4326),
+        'line' => LineString::make([], 4326),
+        'area' => Polygon::make([], 4326),
+    ]);
+
+    Geometry::withCasts([
+        'point' => Polygon::class,
+    ])
+        ->first()
+        ->point;
+})->throws(\InvalidArgumentException::class);

--- a/tests/Models/Location.php
+++ b/tests/Models/Location.php
@@ -2,7 +2,7 @@
 
 namespace Clickbar\Magellan\Tests\Models;
 
-use Clickbar\Magellan\Cast\GeometryCast;
+use Clickbar\Magellan\Data\Geometries\Point;
 use Illuminate\Database\Eloquent\Model;
 
 class Location extends Model
@@ -13,6 +13,6 @@ class Location extends Model
     ];
 
     protected $casts = [
-        'location' => GeometryCast::class,
+        'location' => Point::class,
     ];
 }

--- a/tests/Models/SpatialQueriesTest.php
+++ b/tests/Models/SpatialQueriesTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Clickbar\Magellan\Cast\GeometryCast;
 use Clickbar\Magellan\Data\Geometries\LineString;
 use Clickbar\Magellan\Data\Geometries\MultiPoint;
 use Clickbar\Magellan\Data\Geometries\Point;
@@ -315,7 +314,7 @@ test('it can query expression with array of geometry object, column and closure'
             ST::setSrid('location', 4326),
             fn ($query) => $query->selectRaw('ST_SetSrid(ST_MakePoint(8.625468993349347, 49.87125600428305), 4326)'),
         ]))
-        ->withCasts(['st_collect' => GeometryCast::class])
+        ->withCasts(['st_collect' => MultiPoint::class])
         ->first()
         ->st_collect;
 


### PR DESCRIPTION
Let's write the description by hand again :D

@saibotk  and I realized, that a lot of the time people will use point geometries in their database tables. 
When they use the GeometryCast, an actual `Point` object will be returned, but the type will be the abstract base class `Geometry`. 
So whenever someone use phpstan or want a better auto completion, they will have to write 
```php
/** @var Point $point */
```
what is quite annoying and not properly typ safe. 
So we decided to add a cast for every supported geometry type. 

So in our first approach we came up with something like:
- `PointCast`
- `MultiPointCast`
- `LineStringCast`
- ...

After some consideration we came up with only the specific geometry class as caster.
Just like someone would do it with an enum.

So this PR adds the necessary code to enable stuff like this: 

```php

public array $casts = [
'location' => Point::class,
'area' => Polygon::class,
'line' => LineString::class,
'lines' => MultiLineString::class,
]; 

``` 

Currently this PR only supports Geometries. 
We should also add the same behavior for Box2D and Box3D as well