### PR TITLE
[1.x] Backport: Fix missing precision in WKT coordinates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Fixed only using a precision of 6 decimal digits in WKT, now uses the maximum precision
+
 ## [1.7.0](https://github.com/clickbar/laravel-magellan/tree/1.7.0) - 2024-12-27
 
 ### Added

--- a/src/Data/Geometries/GeometryHelper.php
+++ b/src/Data/Geometries/GeometryHelper.php
@@ -21,7 +21,9 @@ class GeometryHelper
 
     public static function stringifyFloat($float): string
     {
-        // normalized output among locales
-        return trim(trim(rtrim(sprintf('%15F', $float), '0'), '.'));
+        // Use json_encode to use serialization precision instead of
+        // PHP's default format precision.
+        // See https://wiki.php.net/rfc/precise_float_value
+        return json_encode($float);
     }
 }

--- a/tests/Generator/WKT/WKTGeneratorPointTest.php
+++ b/tests/Generator/WKT/WKTGeneratorPointTest.php
@@ -127,3 +127,12 @@ test('can generate 4D WKT Point with SRID', function () {
 
     expect($pointWKT)->toBe('SRID=4326;POINT ZM(8.12345 50.12345 10 20)');
 })->group('WKT Point');
+
+// Test the float precision of the WKT generator
+test('can generate 2D WKT Point with high float precision', function () {
+    $point = Point::make(8.1234567890123456789, 50.123456789012344);
+
+    $pointWKT = $this->generator->generate($point);
+
+    expect($pointWKT)->toBe('POINT(8.123456789012346 50.123456789012344)');
+})->group('WKT Point');


### PR DESCRIPTION
We missed the "." here and thus PHP formatted numbers with the default precision of 6 and prefixed it with whitespaces. See PHP docs: https://www.php.net/manual/en/function.sprintf.php

This has been addressed by using the `json_encode` function to print the float. This function uses PHP's `serialize_precision` instead, which by default uses a similar algorithm to the one PostGIS uses for printing out the float in a minimal representation and also allows to print out at the maximum precision, as long as the user did not change the serialization precision config.

Thanks @ronnypolloqueri for reporting this.

(cherry picked from commit 3c364e39e01b80cae940a81a12315af15a34610a)