### PR TITLE
fix(box): use maximum precision in toString

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed only using a precision of 6 decimal digits in WKT, now uses the maximum precision
+- Fixed only using default PHP string precision in Box `toString` methods, now uses the maximum precision
 
 ### Removed
 

--- a/src/Data/Boxes/Box2D.php
+++ b/src/Data/Boxes/Box2D.php
@@ -2,6 +2,7 @@
 
 namespace Clickbar\Magellan\Data\Boxes;
 
+use Clickbar\Magellan\Data\Geometries\GeometryHelper;
 use Illuminate\Database\Grammar;
 
 class Box2D extends Box
@@ -37,7 +38,10 @@ class Box2D extends Box
 
     public function toString(): string
     {
-        return "BOX({$this->xMin} {$this->yMin},{$this->xMax} {$this->yMax})";
+        $min = GeometryHelper::stringifyFloat($this->xMin).' '.GeometryHelper::stringifyFloat($this->yMin);
+        $max = GeometryHelper::stringifyFloat($this->xMax).' '.GeometryHelper::stringifyFloat($this->yMax);
+
+        return "BOX({$min},{$max})";
     }
 
     public function getValue(Grammar $grammar): string

--- a/src/Data/Boxes/Box3D.php
+++ b/src/Data/Boxes/Box3D.php
@@ -2,6 +2,7 @@
 
 namespace Clickbar\Magellan\Data\Boxes;
 
+use Clickbar\Magellan\Data\Geometries\GeometryHelper;
 use Illuminate\Database\Grammar;
 
 class Box3D extends Box
@@ -47,7 +48,10 @@ class Box3D extends Box
 
     public function toString(): string
     {
-        return "BOX3D({$this->xMin} {$this->yMin} {$this->zMin},{$this->xMax} {$this->yMax} {$this->zMax})";
+        $min = GeometryHelper::stringifyFloat($this->xMin).' '.GeometryHelper::stringifyFloat($this->yMin).' '.GeometryHelper::stringifyFloat($this->zMin);
+        $max = GeometryHelper::stringifyFloat($this->xMax).' '.GeometryHelper::stringifyFloat($this->yMax).' '.GeometryHelper::stringifyFloat($this->zMax);
+
+        return "BOX3D({$min},{$max})";
     }
 
     public function getValue(Grammar $grammar): string

--- a/tests/Data/BoxesTest.php
+++ b/tests/Data/BoxesTest.php
@@ -1,0 +1,16 @@
+<?php
+
+use Clickbar\Magellan\Data\Boxes\Box2D;
+use Clickbar\Magellan\Data\Boxes\Box3D;
+
+test('Box2D retains precision in toString', function () {
+    $box = Box2D::make(1.123456789012345, 2.123456789, 3.123456789, 4.123456789);
+
+    expect($box->toString())->toBe('BOX(1.123456789012345 2.123456789,3.123456789 4.123456789)');
+});
+
+test('Box3D retains precision in toString', function () {
+    $box = Box3D::make(1.123456789012345, 2.123456789, 2.123456789, 3.123456789, 4.123456789, 6.123456789);
+
+    expect($box->toString())->toBe('BOX3D(1.123456789012345 2.123456789 2.123456789,3.123456789 4.123456789 6.123456789)');
+});


### PR DESCRIPTION
The Box classes previously built the string and the floats where cast to string. This looses some precision, because the PHP precision is used instead of the serialization precision.

We now also use the `GeometryHelper` function here, in the same way that we used it in the WKT generator.