### PR TITLE
[2.x] add JsonSerializable to Box classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `withMagellanCasts()` as EloquentBuilder macro
 - Added `AsGeometry` and `AsGeography` database expressions
 - Added `fromString()` to `Box` classes to create a box from a string
+- Added `JsonSerializable` to `Box2D` and `Box3D`
 
 ### Improved
 

--- a/src/Data/Boxes/Box.php
+++ b/src/Data/Boxes/Box.php
@@ -5,8 +5,9 @@ namespace Clickbar\Magellan\Data\Boxes;
 use Clickbar\Magellan\Cast\BBoxCast;
 use Illuminate\Contracts\Database\Eloquent\Castable;
 use Illuminate\Contracts\Database\Query\Expression as ExpressionContract;
+use JsonSerializable;
 
-abstract class Box implements Castable, ExpressionContract
+abstract class Box implements Castable, ExpressionContract, JsonSerializable
 {
     abstract public static function fromString(string $box): self;
 

--- a/src/Data/Boxes/Box2D.php
+++ b/src/Data/Boxes/Box2D.php
@@ -64,4 +64,12 @@ class Box2D extends Box
             floatval($coordinates[4])
         );
     }
+
+    /**
+     * @return array{float, float, float, float}
+     */
+    public function jsonSerialize(): array
+    {
+        return [$this->xMin, $this->yMin, $this->xMax, $this->yMax];
+    }
 }

--- a/src/Data/Boxes/Box3D.php
+++ b/src/Data/Boxes/Box3D.php
@@ -76,4 +76,12 @@ class Box3D extends Box
             floatval($coordinates[6])
         );
     }
+
+    /**
+     * @return array{float, float, float, float, float, float}
+     */
+    public function jsonSerialize(): array
+    {
+        return [$this->xMin, $this->yMin, $this->zMin, $this->xMax, $this->yMax, $this->zMax];
+    }
 }


### PR DESCRIPTION
Box classes now implement `JsonSerializable` and serialize to float arrays, which is a common format in frontend libraries.

Fixes #36