### PR TITLE
[2.x] As helper on MagellanBaseExpression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `Castable` to all geometries to use them as casters, instead of the `GeometryWKBCast`
 - Added `Aliased` Expression class as wrapper for `AS` in query selects
-  - Add `->as()` helper method on MagellanBaseExpression
+  - Added `->as()` helper method on MagellanBaseExpression
 - Added `withMagellanCasts()` as EloquentBuilder macro
 - Added `AsGeometry` and `AsGeography` database expressions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `Castable` to all geometries to use them as casters, instead of the `GeometryWKBCast`
 - Added `Aliased` Expression class as wrapper for `AS` in query selects
+  - Add `->as()` helper method on MagellanBaseExpression
 - Added `withMagellanCasts()` as EloquentBuilder macro
 - Added `AsGeometry` and `AsGeography` database expressions
 

--- a/README.md
+++ b/README.md
@@ -473,8 +473,8 @@ Since "hull" will return a geometry we need a cast for it. Instead of adding eac
 $hullWithArea = Port::query()
     ->select([
         'country',
-        ST::convexHull(ST::collect('location'))->('hull'),
-        ST::area(ST::convexHull(ST::collect('location')))->('area')
+        ST::convexHull(ST::collect('location'))->as('hull'),
+        ST::area(ST::convexHull(ST::collect('location')))->as('area')
     ])
     ->groupBy('country')
     ->withMagellanCasts() /* <======= */
@@ -485,8 +485,8 @@ $hullWithArea = Port::query()
 $hullWithArea = Port::query()
     ->select([
         'country',
-        ST::convexHull(ST::collect('location'))->('hull'),
-        ST::area(ST::convexHull(ST::collect('location')))->('area')
+        ST::convexHull(ST::collect('location'))->as('hull'),
+        ST::area(ST::convexHull(ST::collect('location')))->as('area')
     ])
     ->groupBy('country')
     ->withCasts(['hull' => Polygon::class]) /* <======= */

--- a/src/Database/MagellanExpressions/MagellanBaseExpression.php
+++ b/src/Database/MagellanExpressions/MagellanBaseExpression.php
@@ -4,6 +4,7 @@ namespace Clickbar\Magellan\Database\MagellanExpressions;
 
 use Clickbar\Magellan\Database\Builder\StringifiesQueryParameters;
 use Clickbar\Magellan\Database\Builder\ValueParameter;
+use Clickbar\Magellan\Database\Expressions\Aliased;
 use Clickbar\Magellan\IO\Generator\BaseGenerator;
 use Clickbar\Magellan\IO\Generator\WKT\WKTGenerator;
 use Illuminate\Contracts\Database\Query\Expression;
@@ -63,6 +64,11 @@ abstract class MagellanBaseExpression implements Expression
     public function returnsBbox(): bool
     {
         return $this instanceof MagellanBBoxExpression;
+    }
+
+    public function as(string $name): Expression
+    {
+        return new Aliased($this, $name);
     }
 
     // ######################## Database Expression Building ########################

--- a/tests/Models/SpatialQueriesTest.php
+++ b/tests/Models/SpatialQueriesTest.php
@@ -4,7 +4,6 @@ use Clickbar\Magellan\Data\Geometries\LineString;
 use Clickbar\Magellan\Data\Geometries\MultiPoint;
 use Clickbar\Magellan\Data\Geometries\Point;
 use Clickbar\Magellan\Data\Geometries\Polygon;
-use Clickbar\Magellan\Database\Expressions\Aliased;
 use Clickbar\Magellan\Database\Expressions\AsGeography;
 use Clickbar\Magellan\Database\PostgisFunctions\ST;
 use Clickbar\Magellan\IO\Parser\WKB\WKBParser;
@@ -90,7 +89,7 @@ test('it can calculate distances between points', function () {
     $distances = Location::query()
         ->select([
             'name',
-            new Aliased(ST::distance(new AsGeography('location'), new AsGeography($berlinPoint)), 'distance_in_meters'),
+            ST::distance(new AsGeography('location'), new AsGeography($berlinPoint))->as('distance_in_meters'),
         ])
         ->orderBy('distance_in_meters')
         ->get();
@@ -120,7 +119,7 @@ test('it can find the closest point between geometries', function () {
 
     $closestPoint = Location::query()
         ->where('name', 'Berlin')
-        ->select(new Aliased(ST::closestPoint('location', $hamburg), 'closest_point'))
+        ->select(ST::closestPoint('location', $hamburg)->as('closest_point'))
         ->withMagellanCasts()
         ->first();
 
@@ -144,7 +143,7 @@ test('it can calculate the shortest line between points', function () {
 
     $shortestLine = Location::query()
         ->where('name', 'Berlin')
-        ->select(new Aliased(ST::shortestLine('location', $hamburg), 'shortest_line'))
+        ->select(ST::shortestLine('location', $hamburg)->as('shortest_line'))
         ->withMagellanCasts()
         ->first();
 
@@ -161,7 +160,7 @@ test('it can validate geometry', function () {
     // Check if the point is valid and simple
     $validation = Location::query()
         ->where('id', $berlin->id)
-        ->select(new Aliased(ST::isSimple('location'), 'is_simple'))
+        ->select(ST::isSimple('location')->as('is_simple'))
         ->first();
 
     expect($validation->is_simple)->toBeTrue();
@@ -178,8 +177,8 @@ test('it can check coordinate dimensions', function () {
     $dimensions = Location::query()
         ->where('id', $berlin->id)
         ->select([
-            new Aliased(ST::coordDim('location'), 'coord_dim'),
-            new Aliased(ST::nDims('location'), 'n_dims'),
+            ST::coordDim('location')->as('coord_dim'),
+            ST::nDims('location')->as('n_dims'),
         ])
         ->first();
 
@@ -211,7 +210,7 @@ test('it can calculate 3D distances when altitude is provided', function () {
     // Calculate 3D distance
     $distances = $location3d::query()
         ->where('name', 'Berlin')
-        ->select(new Aliased(ST::distance3D('location', $hamburgWithAltitude), 'distance_3d'))
+        ->select(ST::distance3D('location', $hamburgWithAltitude)->as('distance_3d'))
         ->first();
 
     expect((float) $distances->distance_3d)->toBeFloat();


### PR DESCRIPTION
This PR adds the helper function `->as(string)` on MagellanBaseExpression, that can wrap the expression into an Aliased.

Most of the changes are in Readme and tests :D