### PR TITLE
[2.x] Box: Implement Stringable interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,16 +16,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed automatic SRID transformation
 - Removed st prefixed builder functions (e.g. `stSelect`, `stWhere`, ...)
 - Removed `GeometryType` Enum
+- Renamed `toString` to `toRawSql` on `Box` classes
 
 ### Added
 
 - Added `Castable` to all geometries to use them as casters, instead of the `GeometryWKBCast`
 - Added `Castable` to all boxes to use them as casters, instead of the `BBoxCast`
 - Added `Aliased` Expression class as wrapper for `AS` in query selects
-  - Added `->as()` helper method on MagellanBaseExpression
+    - Added `->as()` helper method on MagellanBaseExpression
 - Added `withMagellanCasts()` as EloquentBuilder macro
 - Added `AsGeometry` and `AsGeography` database expressions
 - Added `fromString()` to `Box` classes to create a box from a string
+- Added `Stringable` interface to all box classes
 - Added `JsonSerializable` to `Box2D` and `Box3D`
 
 ### Improved

--- a/src/Cast/BBoxCast.php
+++ b/src/Cast/BBoxCast.php
@@ -56,6 +56,6 @@ class BBoxCast implements CastsAttributes
      */
     public function set($model, string $key, mixed $value, array $attributes)
     {
-        return $value->toString();
+        return $value->toRawSql();
     }
 }

--- a/src/Data/Boxes/Box.php
+++ b/src/Data/Boxes/Box.php
@@ -6,12 +6,11 @@ use Clickbar\Magellan\Cast\BBoxCast;
 use Illuminate\Contracts\Database\Eloquent\Castable;
 use Illuminate\Contracts\Database\Query\Expression as ExpressionContract;
 use JsonSerializable;
+use Stringable;
 
-abstract class Box implements Castable, ExpressionContract, JsonSerializable
+abstract class Box implements Castable, ExpressionContract, JsonSerializable, Stringable
 {
     abstract public static function fromString(string $box): self;
-
-    abstract public function toString(): string;
 
     /**
      * @return BBoxCast<Box>
@@ -19,5 +18,12 @@ abstract class Box implements Castable, ExpressionContract, JsonSerializable
     public static function castUsing(array $arguments): BBoxCast
     {
         return new BBoxCast(static::class);
+    }
+
+    abstract public function toRawSql(): string;
+
+    public function __toString(): string
+    {
+        return $this->toRawSql();
     }
 }

--- a/src/Data/Boxes/Box2D.php
+++ b/src/Data/Boxes/Box2D.php
@@ -36,7 +36,7 @@ class Box2D extends Box
         return $this->yMax;
     }
 
-    public function toString(): string
+    public function toRawSql(): string
     {
         $min = GeometryHelper::stringifyFloat($this->xMin).' '.GeometryHelper::stringifyFloat($this->yMin);
         $max = GeometryHelper::stringifyFloat($this->xMax).' '.GeometryHelper::stringifyFloat($this->yMax);
@@ -46,7 +46,7 @@ class Box2D extends Box
 
     public function getValue(Grammar $grammar): string
     {
-        return $grammar->quoteString($this->toString()).'::box2d';
+        return $grammar->quoteString($this->toRawSql()).'::box2d';
     }
 
     public static function fromString(string $box): self

--- a/src/Data/Boxes/Box3D.php
+++ b/src/Data/Boxes/Box3D.php
@@ -46,7 +46,7 @@ class Box3D extends Box
         return $this->zMax;
     }
 
-    public function toString(): string
+    public function toRawSql(): string
     {
         $min = GeometryHelper::stringifyFloat($this->xMin).' '.GeometryHelper::stringifyFloat($this->yMin).' '.GeometryHelper::stringifyFloat($this->zMin);
         $max = GeometryHelper::stringifyFloat($this->xMax).' '.GeometryHelper::stringifyFloat($this->yMax).' '.GeometryHelper::stringifyFloat($this->zMax);
@@ -56,7 +56,7 @@ class Box3D extends Box
 
     public function getValue(Grammar $grammar): string
     {
-        return $grammar->quoteString($this->toString()).'::box3d';
+        return $grammar->quoteString($this->toRawSql()).'::box3d';
     }
 
     public static function fromString(string $box): self

--- a/tests/Data/BoxesTest.php
+++ b/tests/Data/BoxesTest.php
@@ -3,14 +3,26 @@
 use Clickbar\Magellan\Data\Boxes\Box2D;
 use Clickbar\Magellan\Data\Boxes\Box3D;
 
-test('Box2D retains precision in toString', function () {
+test('Box2D correctly implements Stringable', function () {
     $box = Box2D::make(1.123456789012345, 2.123456789, 3.123456789, 4.123456789);
 
-    expect($box->toString())->toBe('BOX(1.123456789012345 2.123456789,3.123456789 4.123456789)');
+    expect((string) $box)->toBe('BOX(1.123456789012345 2.123456789,3.123456789 4.123456789)');
 });
 
-test('Box3D retains precision in toString', function () {
+test('Box2D retains precision in toRawSql', function () {
+    $box = Box2D::make(1.123456789012345, 2.123456789, 3.123456789, 4.123456789);
+
+    expect($box->toRawSql())->toBe('BOX(1.123456789012345 2.123456789,3.123456789 4.123456789)');
+});
+
+test('Box3D correctly implements Stringable', function () {
     $box = Box3D::make(1.123456789012345, 2.123456789, 2.123456789, 3.123456789, 4.123456789, 6.123456789);
 
-    expect($box->toString())->toBe('BOX3D(1.123456789012345 2.123456789 2.123456789,3.123456789 4.123456789 6.123456789)');
+    expect((string) $box)->toBe('BOX3D(1.123456789012345 2.123456789 2.123456789,3.123456789 4.123456789 6.123456789)');
+});
+
+test('Box3D retains precision in toRawSql', function () {
+    $box = Box3D::make(1.123456789012345, 2.123456789, 2.123456789, 3.123456789, 4.123456789, 6.123456789);
+
+    expect($box->toRawSql())->toBe('BOX3D(1.123456789012345 2.123456789 2.123456789,3.123456789 4.123456789 6.123456789)');
 });


### PR DESCRIPTION
This properly adds `Stringable` to `Box` classes, so they can be printed etc. We still keep an extra function to create the string, because it concerns the database and should not be tied to the method that converts the object to a string in general.

Fix CB-25