### PR TITLE
Support casting from WKT representation

### DIFF
--- a/src/Cast/GeometryCast.php
+++ b/src/Cast/GeometryCast.php
@@ -6,6 +6,7 @@ use Clickbar\Magellan\Data\Geometries\Geometry;
 use Clickbar\Magellan\IO\Generator\BaseGenerator;
 use Clickbar\Magellan\IO\Generator\WKT\WKTGenerator;
 use Clickbar\Magellan\IO\Parser\WKB\WKBParser;
+use Clickbar\Magellan\IO\Parser\WKT\WKTParser;
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\App;
@@ -21,6 +22,8 @@ class GeometryCast implements CastsAttributes
 {
     protected WKBParser $wkbParser;
 
+    protected WKTParser $wktParser;
+
     protected BaseGenerator $sqlGenerator;
 
     /** @param class-string<T> $geometryClass */
@@ -28,6 +31,7 @@ class GeometryCast implements CastsAttributes
         protected string $geometryClass,
     ) {
         $this->wkbParser = App::make(WKBParser::class);
+        $this->wktParser = App::make(WKTParser::class);
 
         $generatorClass = config('magellan.sql_generator', WKTGenerator::class);
         $this->sqlGenerator = new $generatorClass;
@@ -45,7 +49,12 @@ class GeometryCast implements CastsAttributes
             return null;
         }
 
-        $geometry = $this->wkbParser->parse($value);
+        if (ctype_xdigit($value)) {
+            $geometry = $this->wkbParser->parse($value);
+        } else {
+            $geometry = $this->wktParser->parse($value);
+        }
+
         $this->assertGeometryType($geometry);
 
         return $geometry;

--- a/src/Cast/GeometryCast.php
+++ b/src/Cast/GeometryCast.php
@@ -49,6 +49,7 @@ class GeometryCast implements CastsAttributes
             return null;
         }
 
+        // determine if value is a HEX string
         if (ctype_xdigit($value)) {
             $geometry = $this->wkbParser->parse($value);
         } else {

--- a/tests/Models/LocationTest.php
+++ b/tests/Models/LocationTest.php
@@ -64,3 +64,23 @@ test('it can query points within distance', function () {
     expect($nearbyLocations->pluck('name'))->toContain('Berlin', 'Hamburg');
     expect($nearbyLocations->pluck('name'))->not->toContain('Munich');
 });
+
+test('it can access a point after serializing the model', function () {
+    $location = Location::make([
+        'name' => 'Test Location',
+        'location' => Point::makeGeodetic(51.087, 8.76),
+    ]);
+    $location->save();
+
+    serialize($location);
+
+    expect($location->location)->toBeInstanceOf(Point::class);
+    expect($location->location->getLatitude())->toBe(51.087);
+    expect($location->location->getLongitude())->toBe(8.76);
+
+    // Test after fresh retrieval
+    $location = $location->fresh();
+    expect($location->location)->toBeInstanceOf(Point::class);
+    expect($location->location->getLatitude())->toBe(51.087);
+    expect($location->location->getLongitude())->toBe(8.76);
+});


### PR DESCRIPTION
When an Eloquent model gets serialized, it clears the class cast cache, see [here](https://github.com/laravel/framework/blob/12.x/src/Illuminate/Database/Eloquent/Model.php#L2566). This causes issues with how casting currently works in this library.

Here, a Geometry type attribute is cast from the model representation to the WKT representation, when set. But when fetching from the DB, it casts from WKB to the model representation.

When the class cast cache is populated, this is not a problem. After being set, the cached model representation will be fetched. However, without the cache, when fetching the attribute, it needs to be cast, which it can't because it expects WKB, but gets WKT, resulting in:

```bash
Bad endian byte value 83.

  at src/IO/Parser/WKB/WKBParser.php:125
    121▕
    122▕         $byteOrder = match ($endianValue) {
    123▕             0 => ByteOrder::bigEndian,
    124▕             1 => ByteOrder::littleEndian,
  ➜ 125▕             default => throw new RuntimeException(sprintf('Bad endian byte value %s.', json_encode($endianValue))),
    126▕         };
    127▕
    128▕         $this->scanner->setByteOrder($byteOrder);
    129▕     }

  1   src/IO/Parser/WKB/WKBParser.php:125
  2   src/IO/Parser/WKB/WKBParser.php:38
```

This situation presents itself when using [queueable anonymous event listeners](https://laravel.com/docs/11.x/eloquent#events-using-closures) on the model.

This change fixes this issue.

In the meantime, it could be solved by doing `$model->refresh()` to fetch the WKB representation from the database.