### PR TITLE
Custom SRID on bbox

### DIFF
--- a/src/Cast/BBoxCast.php
+++ b/src/Cast/BBoxCast.php
@@ -23,6 +23,7 @@ class BBoxCast implements CastsAttributes
      */
     public function __construct(
         protected string $boxClass,
+        protected ?int $srid = null
     ) {}
 
     /**
@@ -38,13 +39,13 @@ class BBoxCast implements CastsAttributes
 
         if ($this->boxClass === Box::class) {
             if (Str::contains($value, 'BOX3D', true)) {
-                return Box3D::fromString($value);
+                return Box3D::fromString($value, $this->srid);
             }
 
-            return Box2D::fromString($value);
+            return Box2D::fromString($value, $this->srid);
         }
 
-        return $this->boxClass::fromString($value);
+        return $this->boxClass::fromString($value, $this->srid);
     }
 
     /**

--- a/src/Data/Boxes/Box.php
+++ b/src/Data/Boxes/Box.php
@@ -10,17 +10,25 @@ use Stringable;
 
 abstract class Box implements Castable, ExpressionContract, JsonSerializable, Stringable
 {
-    abstract public static function fromString(string $box): self;
+    protected ?int $srid = null;
+
+    abstract public static function fromString(string $box, ?int $srid = null): self;
 
     /**
      * @return BBoxCast<Box>
      */
     public static function castUsing(array $arguments): BBoxCast
     {
-        return new BBoxCast(static::class);
+        $srid = $arguments[0] ?? null;
+        return new BBoxCast(static::class, $srid);
     }
 
     abstract public function toRawSql(): string;
+
+    public function getSrid(): ?int
+    {
+        return $this->srid;
+    }
 
     public function __toString(): string
     {

--- a/src/Data/Boxes/Box2D.php
+++ b/src/Data/Boxes/Box2D.php
@@ -7,11 +7,11 @@ use Illuminate\Database\Grammar;
 
 class Box2D extends Box
 {
-    private function __construct(protected float $xMin, protected float $yMin, protected float $xMax, protected float $yMax) {}
+    private function __construct(protected float $xMin, protected float $yMin, protected float $xMax, protected float $yMax, protected ?int $srid = null) {}
 
-    public static function make(float $xMin, float $yMin, float $xMax, float $yMax): self
+    public static function make(float $xMin, float $yMin, float $xMax, float $yMax, ?int $srid = null): self
     {
-        return new self($xMin, $yMin, $xMax, $yMax);
+        return new self($xMin, $yMin, $xMax, $yMax, $srid);
     }
 
     public function getXMin(): float
@@ -47,7 +47,7 @@ class Box2D extends Box
         return $grammar->quoteString($this->toRawSql()).'::box2d';
     }
 
-    public static function fromString(string $box): self
+    public static function fromString(string $box, ?int $srid = null): self
     {
         preg_match('/^BOX\(([-+]?\d+(?:.\d+)?)\s([-+]?\d+(?:.\d+)?),([-+]?\d+(?:.\d+)?)\s([-+]?\d+(?:.\d+)?)\)$/i', $box, $coordinates);
 
@@ -59,7 +59,8 @@ class Box2D extends Box
             floatval($coordinates[1]),
             floatval($coordinates[2]),
             floatval($coordinates[3]),
-            floatval($coordinates[4])
+            floatval($coordinates[4]),
+            $srid
         );
     }
 

--- a/src/Data/Boxes/Box3D.php
+++ b/src/Data/Boxes/Box3D.php
@@ -7,11 +7,11 @@ use Illuminate\Database\Grammar;
 
 class Box3D extends Box
 {
-    private function __construct(protected float $xMin, protected float $yMin, protected float $zMin, protected float $xMax, protected float $yMax, protected float $zMax) {}
+    private function __construct(protected float $xMin, protected float $yMin, protected float $zMin, protected float $xMax, protected float $yMax, protected float $zMax, protected ?int $srid = null) {}
 
-    public static function make(float $xMin, float $yMin, float $zMin, float $xMax, float $yMax, float $zMax): self
+    public static function make(float $xMin, float $yMin, float $zMin, float $xMax, float $yMax, float $zMax, ?int $srid = null): self
     {
-        return new self($xMin, $yMin, $zMin, $xMax, $yMax, $zMax);
+        return new self($xMin, $yMin, $zMin, $xMax, $yMax, $zMax, $srid);
     }
 
     public function getXMin(): float
@@ -57,7 +57,7 @@ class Box3D extends Box
         return $grammar->quoteString($this->toRawSql()).'::box3d';
     }
 
-    public static function fromString(string $box): self
+    public static function fromString(string $box, ?int $srid = null): self
     {
         preg_match('/^BOX3D\(([-+]?\d+(?:.\d+)?)\s([-+]?\d+(?:.\d+)?)\s([-+]?\d+(?:.\d+)?),([-+]?\d+(?:.\d+)?)\s([-+]?\d+(?:.\d+)?)\s([-+]?\d+(?:.\d+)?)\)$/i', $box, $coordinates);
 
@@ -71,7 +71,8 @@ class Box3D extends Box
             floatval($coordinates[3]),
             floatval($coordinates[4]),
             floatval($coordinates[5]),
-            floatval($coordinates[6])
+            floatval($coordinates[6]),
+            $srid
         );
     }
 

--- a/tests/Cast/BBoxCastTest.php
+++ b/tests/Cast/BBoxCastTest.php
@@ -1,0 +1,99 @@
+<?php
+
+use Clickbar\Magellan\Cast\BBoxCast;
+use Clickbar\Magellan\Data\Boxes\Box;
+use Clickbar\Magellan\Data\Boxes\Box2D;
+use Clickbar\Magellan\Data\Boxes\Box3D;
+
+test('BBoxCast get returns Box2D with null srid when no srid configured', function () {
+    $cast = new BBoxCast(Box2D::class);
+
+    $box = $cast->get(null, 'bbox', 'BOX(1 2,3 4)', []);
+
+    expect($box)->toBeInstanceOf(Box2D::class);
+    expect($box->getSrid())->toBeNull();
+});
+
+test('BBoxCast get returns Box3D with null srid when no srid configured', function () {
+    $cast = new BBoxCast(Box3D::class);
+
+    $box = $cast->get(null, 'bbox', 'BOX3D(1 2 3,4 5 6)', []);
+
+    expect($box)->toBeInstanceOf(Box3D::class);
+    expect($box->getSrid())->toBeNull();
+});
+
+test('BBoxCast get stamps configured SRID on Box2D', function () {
+    $cast = new BBoxCast(Box2D::class, 4326);
+
+    $box = $cast->get(null, 'bbox', 'BOX(1 2,3 4)', []);
+
+    expect($box)->toBeInstanceOf(Box2D::class);
+    expect($box->getSrid())->toBe(4326);
+});
+
+test('BBoxCast get stamps configured SRID on Box3D', function () {
+    $cast = new BBoxCast(Box3D::class, 4326);
+
+    $box = $cast->get(null, 'bbox', 'BOX3D(1 2 3,4 5 6)', []);
+
+    expect($box)->toBeInstanceOf(Box3D::class);
+    expect($box->getSrid())->toBe(4326);
+});
+
+test('BBoxCast get auto-detects Box2D from BOX string and stamps SRID', function () {
+    $cast = new BBoxCast(Box::class, 4326);
+
+    $box = $cast->get(null, 'bbox', 'BOX(1 2,3 4)', []);
+
+    expect($box)->toBeInstanceOf(Box2D::class);
+    expect($box->getSrid())->toBe(4326);
+});
+
+test('BBoxCast get auto-detects Box3D from BOX3D string and stamps SRID', function () {
+    $cast = new BBoxCast(Box::class, 4326);
+
+    $box = $cast->get(null, 'bbox', 'BOX3D(1 2 3,4 5 6)', []);
+
+    expect($box)->toBeInstanceOf(Box3D::class);
+    expect($box->getSrid())->toBe(4326);
+});
+
+test('BBoxCast get returns null for null value', function () {
+    $cast = new BBoxCast(Box2D::class, 4326);
+
+    expect($cast->get(null, 'bbox', null, []))->toBeNull();
+});
+
+test('BBoxCast set returns raw SQL string, SRID has no effect', function () {
+    $cast = new BBoxCast(Box2D::class, 4326);
+    $box = Box2D::make(1.0, 2.0, 3.0, 4.0, 4326);
+
+    expect($cast->set(null, 'bbox', $box, []))->toBe('BOX(1 2,3 4)');
+});
+
+test('Box2D::castUsing without srid argument creates BBoxCast with null srid', function () {
+    $cast = Box2D::castUsing([]);
+
+    $box = $cast->get(null, 'bbox', 'BOX(1 2,3 4)', []);
+
+    expect($box->getSrid())->toBeNull();
+});
+
+test('Box2D::castUsing with srid argument creates BBoxCast that stamps SRID', function () {
+    $cast = Box2D::castUsing([4326]);
+
+    $box = $cast->get(null, 'bbox', 'BOX(1 2,3 4)', []);
+
+    expect($box)->toBeInstanceOf(Box2D::class);
+    expect($box->getSrid())->toBe(4326);
+});
+
+test('Box3D::castUsing with srid argument creates BBoxCast that stamps SRID', function () {
+    $cast = Box3D::castUsing([4326]);
+
+    $box = $cast->get(null, 'bbox', 'BOX3D(1 2 3,4 5 6)', []);
+
+    expect($box)->toBeInstanceOf(Box3D::class);
+    expect($box->getSrid())->toBe(4326);
+});

--- a/tests/Data/BoxesTest.php
+++ b/tests/Data/BoxesTest.php
@@ -3,6 +3,66 @@
 use Clickbar\Magellan\Data\Boxes\Box2D;
 use Clickbar\Magellan\Data\Boxes\Box3D;
 
+test('Box2D::make without SRID has null srid', function () {
+    $box = Box2D::make(1.0, 2.0, 3.0, 4.0);
+
+    expect($box->getSrid())->toBeNull();
+});
+
+test('Box2D::make with SRID returns correct srid', function () {
+    $box = Box2D::make(1.0, 2.0, 3.0, 4.0, 4326);
+
+    expect($box->getSrid())->toBe(4326);
+});
+
+test('Box2D::fromString without SRID has null srid', function () {
+    $box = Box2D::fromString('BOX(1 2,3 4)');
+
+    expect($box->getSrid())->toBeNull();
+});
+
+test('Box2D::fromString with SRID returns correct srid', function () {
+    $box = Box2D::fromString('BOX(1 2,3 4)', 4326);
+
+    expect($box->getSrid())->toBe(4326);
+});
+
+test('Box2D SRID does not affect toRawSql output', function () {
+    $box = Box2D::make(1.0, 2.0, 3.0, 4.0, 4326);
+
+    expect($box->toRawSql())->toBe('BOX(1 2,3 4)');
+});
+
+test('Box3D::make without SRID has null srid', function () {
+    $box = Box3D::make(1.0, 2.0, 3.0, 4.0, 5.0, 6.0);
+
+    expect($box->getSrid())->toBeNull();
+});
+
+test('Box3D::make with SRID returns correct srid', function () {
+    $box = Box3D::make(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 4326);
+
+    expect($box->getSrid())->toBe(4326);
+});
+
+test('Box3D::fromString without SRID has null srid', function () {
+    $box = Box3D::fromString('BOX3D(1 2 3,4 5 6)');
+
+    expect($box->getSrid())->toBeNull();
+});
+
+test('Box3D::fromString with SRID returns correct srid', function () {
+    $box = Box3D::fromString('BOX3D(1 2 3,4 5 6)', 4326);
+
+    expect($box->getSrid())->toBe(4326);
+});
+
+test('Box3D SRID does not affect toRawSql output', function () {
+    $box = Box3D::make(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 4326);
+
+    expect($box->toRawSql())->toBe('BOX3D(1 2 3,4 5 6)');
+});
+
 test('Box2D correctly implements Stringable', function () {
     $box = Box2D::make(1.123456789012345, 2.123456789, 3.123456789, 4.123456789);
 


### PR DESCRIPTION
Just like geojson, bbox'es can be in different SRIDs than 4326 (see #150). Even though the SRID is not saved with the bounding box in the database, it might be useful to keep track of the SRID within the application in case transformations are necessary. 

The changes are in the Box dto's and the cast class.

Before updating docs and changelog, here is a draft PR for discussion.